### PR TITLE
EmojiPort: Replace apt.bingner.com with repo.bingner.com for iOS 10-

### DIFF
--- a/emojiport.html
+++ b/emojiport.html
@@ -376,13 +376,13 @@
                 <hr>
                 <code>
                     TL;DR:<br>
-                    1. Add these repositories to your package manager: <a href=https://apt.bingner.com>apt.bingner.com</a> (iOS 11- AND non-Electra jailbreak), <a href=https://apt.thebigboss.org/repofiles/cydia>apt.thebigboss.org/repofiles/cydia</a>, <a href=https://repo.chariz.com>repo.chariz.com</a>, <a href="https://opa334.github.io">https://opa334.github.io</a> and <a href=https://poomsmart.github.io/repo>poomsmart.github.io/repo</a><br>
+                    1. Add these repositories to your package manager: <a href=https://repo.bingner.com>repo.bingner.com</a> (iOS 10-), <a href=https://apt.thebigboss.org/repofiles/cydia>apt.thebigboss.org/repofiles/cydia</a>, <a href=https://repo.chariz.com>repo.chariz.com</a>, <a href="https://opa334.github.io">https://opa334.github.io</a> and <a href=https://poomsmart.github.io/repo>poomsmart.github.io/repo</a><br>
                     2. Install "EFM Font Setter" and "EmojiPort (YOUR IOS VERSION)" tweak<br>
                     3. Respring
                 </code>
                 <hr>
                 <p>First of all, add these repositories if not already:
-                    <a href=https://apt.bingner.com>apt.bingner.com</a> (if you are on iOS 11 or lower AND you are not on Electra jailbreak),
+                    <a href=https://repo.bingner.com>repo.bingner.com</a> (if you are on iOS 10 or lower),
                     <a href=https://apt.thebigboss.org/repofiles/cydia>apt.thebigboss.org/repofiles/cydia</a>,
                     <a href=https://opa334.github.io>opa334.github.io</a>,
                     <a href=https://repo.chariz.com>repo.chariz.com</a> and
@@ -401,7 +401,6 @@
                     <b>
 						<li>Disable any emoji font applied by Anemone, as this tweak simply overrides it.</li>
 					</b>
-                    <li>(iOS 10 or lower) Upgrade all packages from apt.bingner.com, if not already.</li>
                     <li>Install
                         <b>EmojiFontManager</b> and
                         <b>AppleColorEmoji Unicode [UVERSION] (EFM)</b> font (<code>com.ps.emojifontefm</code>)</li>


### PR DESCRIPTION
Switch to adding `repo.bingner.com` instead of `apt.bingner.com` for getting an updated curl package to download the emojis needed

This keeps the change minimal, where only curl will be updated instead of also updating other packages, which makes things a bit safer overall

Also, `apt.bingner.com` is mainly intended for unc0ver/checkra1n and may have some quirks on older 32-bit iOS 10 and below with Cydia/Telesphoreo. Using `repo.bingner.com` avoids that and keeps things simpler/safer

<details>
<summary>Tested on iOS 5.1.1</summary>

```
iPhone:~ root# sw_vers      
ProductName:    iPhone OS
ProductVersion: 5.1.1
BuildVersion:   9B206
iPhone:~ root# curl --version
curl 7.58.0-DEV (armv6-apple-darwin) libcurl/7.58.0-DEV SecureTransport zlib/1.2.5
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp 
Features: AsynchDNS IPv6 Largefile NTLM NTLM_WB SSL libz UnixSockets 
iPhone:~ root# curl -LO https://github.com/PoomSmart/EmojiFonts/releases/download/17.0.0/AppleColorEmoji.ttc
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 32.3M  100 32.3M    0     0  1677k      0  0:00:19  0:00:19 --:--:-- 1670k
iPhone:~ root# 
```

</details>